### PR TITLE
Feature navigation menu for pages

### DIFF
--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -43,7 +43,7 @@ class CategorySidebar extends React.Component {
             <i className={'fas fa-chevron-left'} />
           </Link>
           <div className={'is-3 has-text-white has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
-            {activeCategoryName}
+            {activeCategoryName.replace(/_/g, ' ')}
           </div>
           <Link to={nextData.url} className={'icon has-text-white has-background-info plr1'}>
             <i className={'fas fa-chevron-right'} />
@@ -63,6 +63,10 @@ class CategorySidebar extends React.Component {
     if (!pages) {
       return null
     }
+    if (!this.props.match.params.page) {
+      return pages[0]
+    }
+
     return pages.find(page => urlify(page.title).toLowerCase() === this.props.match.params.page.toLowerCase())
   }
 

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withRouter } from 'react-router'
 import connect from 'react-redux/es/connect/connect'
 import { Link } from 'react-router-dom'
-import { urlify } from '../../lib/helpers'
+import { getNextPageData, getPreviousPageData, urlify } from '../../lib/helpers'
 
 class CategorySidebar extends React.Component {
   getStepsForPages(category, pages) {
@@ -28,21 +28,25 @@ class CategorySidebar extends React.Component {
   }
 
   render() {
-    let activeCategoryName = this.props.match.params.category
+    const activeCategoryName = this.props.match.params.category
     const activeCategoryPages = this.props.categories[urlify(activeCategoryName.toLowerCase())]
+
+    const activePage = this.getCurrentPage()
+    const previousUrl = getPreviousPageData(activePage, activeCategoryName, activeCategoryPages).url
+    const nextUrl = getNextPageData(activePage, activeCategoryName, activeCategoryPages).url
 
     return (
       <div className={'category-sidebar border-shadow'}>
         <div className={'sidebar-header is-flex is-stretch has-text-white has-text-centered'}>
-          <div className={'icon has-background-info plr1'}>
+          <Link to={previousUrl} className={'icon has-background-info plr1'}>
             <i className={'fas fa-chevron-left'} />
-          </div>
+          </Link>
           <div className={'is-3 has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
             {activeCategoryName}
           </div>
-          <div className={'icon has-background-info plr1'}>
+          <Link to={nextUrl} className={'icon has-background-info plr1'}>
             <i className={'fas fa-chevron-right'} />
-          </div>
+          </Link>
         </div>
         <aside className="menu">
           <ul className="menu-list pbt5">{this.getStepsForPages(activeCategoryName, activeCategoryPages)}</ul>
@@ -51,10 +55,20 @@ class CategorySidebar extends React.Component {
     )
   }
 
+  getCurrentPage() {
+    let category = this.props.match.params.category
+    const pages = this.props.categories[urlify(category.toLowerCase())]
+
+    if (!pages) {
+      return null
+    }
+    return pages.find(page => page.title.toLowerCase() === this.props.match.params.page.toLowerCase())
+  }
+
   isActivePage(page, isOverview) {
     return (
-      (isOverview && !this.props.match.params.page) ||
-      (this.props.match.params.page && this.props.match.params.page.toLowerCase() === urlify(page.title.toLowerCase()))
+      (isOverview && !this.getCurrentPage()) ||
+      (this.getCurrentPage() && this.getCurrentPage().title.toLowerCase() === urlify(page.title.toLowerCase()))
     )
   }
 }

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -32,11 +32,20 @@ class CategorySidebar extends React.Component {
     const activeCategoryPages = this.props.categories[urlify(activeCategoryName.toLowerCase())]
 
     return (
-      <div className={'category-sidebar'}>
-        <h1 className={'title'}>Smart contracts</h1>
+      <div className={'category-sidebar border-shadow'}>
+        <div className={'sidebar-header is-flex is-stretch has-text-white has-text-centered'}>
+          <div className={'icon has-background-info plr1'}>
+            <i className={'fas fa-chevron-left'} />
+          </div>
+          <div className={'is-3 has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
+            {activeCategoryName}
+          </div>
+          <div className={'icon has-background-info plr1'}>
+            <i className={'fas fa-chevron-right'} />
+          </div>
+        </div>
         <aside className="menu">
-          <p className={'menu-label'}>General</p>
-          <ul className="menu-list">{this.getStepsForPages(activeCategoryName, activeCategoryPages)}</ul>
+          <ul className="menu-list pbt5">{this.getStepsForPages(activeCategoryName, activeCategoryPages)}</ul>
         </aside>
       </div>
     )

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -14,7 +14,7 @@ class CategorySidebar extends React.Component {
     for (const page of pages) {
       const isOverview = page.url.endsWith('/')
       const title = isOverview ? 'Overview' : page.title
-      const url = `/pages/${category}` + !isOverview ? `/${urlify(title)}` : ''
+      const url = `/pages/${category}` + (!isOverview ? `/${urlify(title)}` : '')
 
       steps.push(
         <li key={page.url}>

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+import connect from 'react-redux/es/connect/connect'
+import { Link } from 'react-router-dom'
+import { urlify } from '../../lib/helpers'
+
+class CategorySidebar extends React.Component {
+  getStepsForPages(category, pages) {
+    if (!pages) {
+      return []
+    }
+    const steps = []
+
+    for (const page of pages) {
+      const isOverview = page.url.endsWith('/')
+      const title = isOverview ? 'Overview' : page.title
+      const url = `/pages/${category}` + !isOverview ? `/${urlify(title)}` : ''
+
+      steps.push(
+        <li key={page.url}>
+          <Link to={url} className={`text ${this.isActivePage(page, isOverview) ? 'is-active' : ''}`}>
+            {title}
+          </Link>
+        </li>,
+      )
+    }
+    return steps
+  }
+
+  render() {
+    let activeCategoryName = this.props.match.params.category
+    const activeCategoryPages = this.props.categories[urlify(activeCategoryName.toLowerCase())]
+
+    return (
+      <div className={'category-sidebar'}>
+        <h1 className={'title'}>Smart contracts</h1>
+        <aside className="menu">
+          <p className={'menu-label'}>General</p>
+          <ul className="menu-list">{this.getStepsForPages(activeCategoryName, activeCategoryPages)}</ul>
+        </aside>
+      </div>
+    )
+  }
+
+  isActivePage(page, isOverview) {
+    return (
+      (isOverview && !this.props.match.params.page) ||
+      (this.props.match.params.page && this.props.match.params.page.toLowerCase() === urlify(page.title.toLowerCase()))
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  categories: state.categories,
+})
+
+const ConnectedCategorySidebar = connect(mapStateToProps)(CategorySidebar)
+export default withRouter(ConnectedCategorySidebar)

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -37,14 +37,14 @@ class CategorySidebar extends React.Component {
 
     return (
       <div className={'category-sidebar border-shadow'}>
-        <div className={'sidebar-header is-flex is-stretch has-text-white has-text-centered'}>
-          <Link to={previousUrl} className={'icon has-background-info plr1'}>
+        <div className={'sidebar-header is-flex is-stretch has-text-centered'}>
+          <Link to={previousUrl} className={'icon has-text-white has-background-info plr1'}>
             <i className={'fas fa-chevron-left'} />
           </Link>
-          <div className={'is-3 has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
+          <div className={'is-3 has-text-white has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
             {activeCategoryName}
           </div>
-          <Link to={nextUrl} className={'icon has-background-info plr1'}>
+          <Link to={nextUrl} className={'icon has-text-white has-background-info plr1'}>
             <i className={'fas fa-chevron-right'} />
           </Link>
         </div>
@@ -57,18 +57,17 @@ class CategorySidebar extends React.Component {
 
   getCurrentPage() {
     let category = this.props.match.params.category
-    const pages = this.props.categories[urlify(category.toLowerCase())]
+    const pages = this.props.categories[urlify(category).toLowerCase()]
 
     if (!pages) {
       return null
     }
-    return pages.find(page => page.title.toLowerCase() === this.props.match.params.page.toLowerCase())
+    return pages.find(page => urlify(page.title).toLowerCase() === this.props.match.params.page.toLowerCase())
   }
 
   isActivePage(page, isOverview) {
     return (
-      (isOverview && !this.getCurrentPage()) ||
-      (this.getCurrentPage() && this.getCurrentPage().title.toLowerCase() === urlify(page.title.toLowerCase()))
+      (isOverview && !this.getCurrentPage()) || (this.getCurrentPage() && this.getCurrentPage().title === page.title)
     )
   }
 }

--- a/src/components/layout/CategorySidebar.js
+++ b/src/components/layout/CategorySidebar.js
@@ -30,21 +30,22 @@ class CategorySidebar extends React.Component {
   render() {
     const activeCategoryName = this.props.match.params.category
     const activeCategoryPages = this.props.categories[urlify(activeCategoryName.toLowerCase())]
-
     const activePage = this.getCurrentPage()
-    const previousUrl = getPreviousPageData(activePage, activeCategoryName, activeCategoryPages).url
-    const nextUrl = getNextPageData(activePage, activeCategoryName, activeCategoryPages).url
+
+    const pages = Object.values(this.props.categories).reduce((acc, cat) => [...acc, ...cat], [])
+    const previousData = getPreviousPageData(activePage, activeCategoryName, pages)
+    const nextData = getNextPageData(activePage, activeCategoryName, pages)
 
     return (
       <div className={'category-sidebar border-shadow'}>
         <div className={'sidebar-header is-flex is-stretch has-text-centered'}>
-          <Link to={previousUrl} className={'icon has-text-white has-background-info plr1'}>
+          <Link to={previousData.url} className={'icon has-text-white has-background-info plr1'}>
             <i className={'fas fa-chevron-left'} />
           </Link>
           <div className={'is-3 has-text-white has-text-weight-bold has-flex-grow has-background-info pbt05 plr075'}>
             {activeCategoryName}
           </div>
-          <Link to={nextUrl} className={'icon has-text-white has-background-info plr1'}>
+          <Link to={nextData.url} className={'icon has-text-white has-background-info plr1'}>
             <i className={'fas fa-chevron-right'} />
           </Link>
         </div>

--- a/src/components/layout/CategorySteps.js
+++ b/src/components/layout/CategorySteps.js
@@ -14,7 +14,7 @@ class CategorySteps extends React.Component {
     for (const page of pages) {
       const isOverview = page.url.endsWith('/')
       const title = isOverview ? 'Overview' : page.title
-      const url = `/pages/${category}` + !isOverview ? `/${urlify(title)}` : ''
+      const url = `/pages/${category}` + (!isOverview ? `/${urlify(title)}` : '')
 
       steps.push(
         <li key={page.url} className={`steps-segment ${this.isActivePage(page, isOverview) ? 'is-active' : ''}`}>

--- a/src/components/page/Page.js
+++ b/src/components/page/Page.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Redirect, withRouter } from 'react-router-dom'
 import TitleHeader from '../layout/TitleHeader'
 import CategorySteps from '../layout/CategorySteps'
+import CategorySidebar from '../layout/CategorySidebar'
 import connect from 'react-redux/es/connect/connect'
 import { buildCategoryUrl, urlify } from '../../lib/helpers'
 import PageContent from './PageContent'
@@ -32,21 +33,7 @@ class Page extends React.Component {
               <PageContent page={page} category={categoryName} />
             </div>
             <div className={'column is-one-quarter'}>
-              <h1 className={'title'}>Smart contracts</h1>
-              <aside className="menu">
-                <p className={'menu-label'}>General</p>
-                <ul className="menu-list">
-                  <li>
-                    <a className="text">Functions</a>
-                  </li>
-                  <li>
-                    <a className="text">Payments</a>
-                  </li>
-                  <li>
-                    <a className="text is-active">Start Learning</a>
-                  </li>
-                </ul>
-              </aside>
+              <CategorySidebar />
             </div>
           </div>
         </div>

--- a/src/components/page/PageContent.js
+++ b/src/components/page/PageContent.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { buildCategoryUrl, buildPageUrl, firstCategoryNameOrUnknown, urlify } from '../../lib/helpers'
+import { getAdjacentCategoryPage, getNextPageData, getPreviousPageData } from '../../lib/helpers'
 import { loadPageContent } from '../../actions/pages'
 import ContentArray from './ContentArray'
 
@@ -78,30 +78,7 @@ class PageContent extends React.Component {
   }
 
   getNextPageJSX() {
-    const nextPage = this.props.page ? this.getAdjacentCategoryPage(this.props.page.next, 'next') : null
-
-    let url
-    let text
-    if (!nextPage || !nextPage.categories) {
-      // Search page
-      url = '/search'
-      text = 'Choose next page'
-    } else if (
-      nextPage.categories &&
-      nextPage.categories.map(c => c.toLowerCase()).includes(this.props.category.toLowerCase())
-    ) {
-      // Next Page
-      url = buildPageUrl(this.props.category, nextPage.title)
-      text = nextPage.title
-    } else if (nextPage.url.endsWith('/')) {
-      // Next Chapter
-      url = buildCategoryUrl(nextPage.categories[0])
-      text = nextPage.title
-    } else {
-      // Next Chapter
-      url = buildPageUrl(nextPage.categories[0], nextPage.title)
-      text = nextPage.title
-    }
+    let { url, text } = this.getNextPageData()
 
     return (
       <Link to={url} className={'button is-info is-outlined is-uppercase'}>
@@ -114,54 +91,28 @@ class PageContent extends React.Component {
   }
 
   getPreviousPageJSX() {
-    const previousPage = this.props.page ? this.getAdjacentCategoryPage(this.props.page.previous, 'prev') : null
-
-    if (!previousPage) {
-      return null
-    }
-
-    const sameCategory =
-      previousPage &&
-      previousPage.categories &&
-      previousPage.categories.map(c => urlify(c.toLowerCase())).includes(this.props.category.toLowerCase())
-
-    let url
-    if (sameCategory) {
-      if (previousPage.url.endsWith('/')) {
-        // Chapter overview
-        url = buildCategoryUrl(this.props.category)
-      } else {
-        // Regular page
-        url = buildPageUrl(this.props.category, previousPage.title)
-      }
-    } else {
-      // Previous Chapter
-      url = buildPageUrl(firstCategoryNameOrUnknown(previousPage.categories), previousPage.title)
-    }
+    const { url, text } = this.getPreviousPageData()
 
     return (
       <Link to={url} className={'button is-info is-outlined is-uppercase'}>
         <div className={'icon'}>
           <i className={'fas fa-chevron-left'} />
         </div>
-        <span>{previousPage.title}</span>
+        <span>{text}</span>
       </Link>
     )
   }
 
   getAdjacentCategoryPage(nextPreviousContainer, info) {
-    if (nextPreviousContainer) {
-      const categoryIndex = this.props.page.categories
-        .map(cat => urlify(cat.toLowerCase()))
-        .indexOf(this.props.category.toLowerCase())
-      if (categoryIndex !== -1) {
-        return this.props.pages.find(
-          page => page.url.toLowerCase() === nextPreviousContainer[categoryIndex].toLowerCase(),
-        )
-      } else if (info === 'next') {
-        console.log('-1 next', this.props.page.categories, this.props.category)
-      }
-    }
+    return getAdjacentCategoryPage(this.props.page, this.props.category, this.props.pages, nextPreviousContainer, info)
+  }
+
+  getPreviousPageData() {
+    return getPreviousPageData(this.props.page, this.props.category, this.props.pages)
+  }
+
+  getNextPageData() {
+    return getNextPageData(this.props.page, this.props.category, this.props.pages)
   }
 }
 

--- a/src/components/page/PageContent.js
+++ b/src/components/page/PageContent.js
@@ -19,8 +19,12 @@ class PageContent extends React.Component {
   loadCurrentPageContent() {
     this.loadPageContent(this.props.page)
     if (this.props.page) {
-      this.loadPageContent(this.getAdjacentCategoryPage(this.props.page.next))
-      this.loadPageContent(this.getAdjacentCategoryPage(this.props.page.previous))
+      this.loadPageContent(
+        getAdjacentCategoryPage(this.props.page, this.props.category, this.props.pages, this.props.page.next),
+      )
+      this.loadPageContent(
+        getAdjacentCategoryPage(this.props.page, this.props.category, this.props.pages, this.props.page.previous),
+      )
     }
   }
 
@@ -78,7 +82,7 @@ class PageContent extends React.Component {
   }
 
   getNextPageJSX() {
-    let { url, text } = this.getNextPageData()
+    let { url, text } = getNextPageData(this.props.page, this.props.category, this.props.pages)
 
     return (
       <Link to={url} className={'button is-info is-outlined is-uppercase'}>
@@ -91,7 +95,7 @@ class PageContent extends React.Component {
   }
 
   getPreviousPageJSX() {
-    const { url, text } = this.getPreviousPageData()
+    const { url, text } = getPreviousPageData(this.props.page, this.props.category, this.props.pages)
 
     return (
       <Link to={url} className={'button is-info is-outlined is-uppercase'}>
@@ -101,18 +105,6 @@ class PageContent extends React.Component {
         <span>{text}</span>
       </Link>
     )
-  }
-
-  getAdjacentCategoryPage(nextPreviousContainer, info) {
-    return getAdjacentCategoryPage(this.props.page, this.props.category, this.props.pages, nextPreviousContainer, info)
-  }
-
-  getPreviousPageData() {
-    return getPreviousPageData(this.props.page, this.props.category, this.props.pages)
-  }
-
-  getNextPageData() {
-    return getNextPageData(this.props.page, this.props.category, this.props.pages)
   }
 }
 

--- a/src/components/page/Pages.js
+++ b/src/components/page/Pages.js
@@ -55,10 +55,10 @@ class Pages extends React.Component {
       content = this.getCategoryInfo(activeCategoryPages, activeCategoryName)
     }
     return (
-      <section className="hero">
+      <section className={'hero'}>
         <TitleHeader />
-        <div className="hero-body">
-          <div className="container has-text-centered">{content}</div>
+        <div className={'hero-body content'}>
+          <div>{content}</div>
         </div>
       </section>
     )

--- a/src/components/page/Pages.js
+++ b/src/components/page/Pages.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { Link, withRouter } from 'react-router-dom'
 import TitleHeader from '../layout/TitleHeader'
 import { getDifficultyColorForTag, urlify } from '../../lib/helpers'
+import CategorySidebar from '../layout/CategorySidebar'
 import CategorySteps from '../layout/CategorySteps'
 import PageContent from './PageContent'
 
@@ -68,10 +69,17 @@ class Pages extends React.Component {
     return (
       <>
         <CategorySteps />
-        <div className="tile is-ancestor columns is-multiline">
-          {this.getTilesForPages(categoryName, categoryPages)}
+        <div className="columns">
+          <div className={'column'}>
+            <div className="tile is-ancestor columns is-multiline">
+              {this.getTilesForPages(categoryName, categoryPages)}
+            </div>
+            <PageContent page={categoryRootPage} category={categoryName} categoryPage />
+          </div>
+          <div className={'column is-one-quarter'}>
+            <CategorySidebar />
+          </div>
         </div>
-        <PageContent page={categoryRootPage} category={categoryName} categoryPage />
       </>
     )
   }

--- a/src/index.css
+++ b/src/index.css
@@ -325,3 +325,14 @@ code {
 .ace-dracula {
     border-radius: 8px;
 }
+
+.menu .menu-list {
+    list-style: none;
+    margin-left: 0;
+    margin-top: 0;
+}
+
+.steps.my-step-style {
+    list-style: none;
+    margin-left: 0;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -66,6 +66,26 @@ code {
     padding: 5px;
 }
 
+.pbt5 {
+    padding-bottom: 5px;
+    padding-top: 5px;
+}
+
+.pbt05 {
+    padding-bottom: 0.5em;
+    padding-top: 0.5em;
+}
+
+.plr075 {
+    padding-left: 0.75em;
+    padding-right: 0.75em;
+}
+
+.plr1 {
+    padding-left: 1rem;
+    padding-right: 1rem;
+}
+
 .is-parent .tile:hover {
     background-color: azure;
 }
@@ -335,4 +355,32 @@ code {
 .steps.my-step-style {
     list-style: none;
     margin-left: 0;
+}
+
+.has-flex-grow {
+    flex-grow: 1;
+}
+
+.sidebar-header > :first-child {
+    border-top-left-radius: 8px;
+    margin-right: 2px;
+    height: auto;
+}
+
+.sidebar-header > :last-child {
+    border-top-right-radius: 8px;
+    margin-left: 2px;
+    height: auto;
+}
+
+.is-stretch {
+    align-items: stretch;
+}
+
+.menu-list a.is-active {
+    background-color: #209cee;
+}
+
+.category-sidebar .menu-list a.is-active {
+    background-color: #70bdf4;
 }

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -45,7 +45,7 @@ export const postUrl = (url, data) => {
   return axios({ method: 'post', url: url, data: data })
 }
 
-export const getAdjacentCategoryPage = (page, category, pages, nextPreviousContainer, info) => {
+export const getAdjacentCategoryPage = (page, category, pages, nextPreviousContainer) => {
   if (nextPreviousContainer && category) {
     const categoryIndex = page.categories.map(cat => urlify(cat.toLowerCase())).indexOf(category.toLowerCase())
     if (categoryIndex !== -1) {
@@ -55,15 +55,12 @@ export const getAdjacentCategoryPage = (page, category, pages, nextPreviousConta
           page.url.toLowerCase() === nextPreviousContainer[categoryIndex].toLowerCase(),
       )
     }
-    if (info === 'next') {
-      console.log('-1 next', page.categories, category)
-    }
   }
   return null
 }
 
 export const getPreviousPageData = (page, category, pages) => {
-  const previousPage = page ? getAdjacentCategoryPage(page, category, pages, page.previous, 'prev') : null
+  const previousPage = page ? getAdjacentCategoryPage(page, category, pages, page.previous) : null
 
   let url
   let text
@@ -97,7 +94,7 @@ export const getPreviousPageData = (page, category, pages) => {
 }
 
 export const getNextPageData = (page, category, pages) => {
-  const nextPage = page ? getAdjacentCategoryPage(page, category, pages, page.next, 'next') : null
+  const nextPage = page ? getAdjacentCategoryPage(page, category, pages, page.next) : null
 
   let url
   let text

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -44,3 +44,78 @@ export const fetchUrl = url => {
 export const postUrl = (url, data) => {
   return axios({ method: 'post', url: url, data: data })
 }
+
+export const getAdjacentCategoryPage = (page, category, pages, nextPreviousContainer, info) => {
+  if (nextPreviousContainer) {
+    const categoryIndex = page.categories.map(cat => urlify(cat.toLowerCase())).indexOf(category.toLowerCase())
+    if (categoryIndex !== -1) {
+      return pages.find(
+        page =>
+          nextPreviousContainer[categoryIndex] &&
+          page.url.toLowerCase() === nextPreviousContainer[categoryIndex].toLowerCase(),
+      )
+    }
+    if (info === 'next') {
+      console.log('-1 next', page.categories, category)
+    }
+  }
+}
+
+export const getPreviousPageData = (page, category, pages) => {
+  const previousPage = page ? getAdjacentCategoryPage(page, category, pages, page.previous, 'prev') : null
+
+  let url
+  let text
+  if (!previousPage) {
+    url = '/'
+    text = 'Homepage'
+  } else {
+    text = previousPage.title
+  }
+
+  const sameCategory =
+    previousPage &&
+    previousPage.categories &&
+    previousPage.categories.map(c => urlify(c.toLowerCase())).includes(category.toLowerCase())
+
+  if (sameCategory) {
+    if (previousPage.url.endsWith('/')) {
+      // Chapter overview
+      url = buildCategoryUrl(category)
+    } else {
+      // Regular page
+      url = buildPageUrl(category, previousPage.title)
+    }
+  } else {
+    // Previous Chapter
+    url = buildPageUrl(firstCategoryNameOrUnknown(previousPage.categories), previousPage.title)
+  }
+
+  return { url, text }
+}
+
+export const getNextPageData = (page, category, pages) => {
+  const nextPage = page ? getAdjacentCategoryPage(page, category, pages, page.next, 'next') : null
+
+  let url
+  let text
+  if (!nextPage || !nextPage.categories) {
+    // Search page
+    url = '/search'
+    text = 'Choose next page'
+  } else if (nextPage.categories && nextPage.categories.map(c => c.toLowerCase()).includes(category.toLowerCase())) {
+    // Next Page
+    url = buildPageUrl(category, nextPage.title)
+    text = nextPage.title
+  } else if (nextPage.url.endsWith('/')) {
+    // Next Chapter
+    url = buildCategoryUrl(nextPage.categories[0])
+    text = nextPage.title
+  } else {
+    // Next Chapter
+    url = buildPageUrl(nextPage.categories[0], nextPage.title)
+    text = nextPage.title
+  }
+
+  return { url, text }
+}

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -46,7 +46,7 @@ export const postUrl = (url, data) => {
 }
 
 export const getAdjacentCategoryPage = (page, category, pages, nextPreviousContainer, info) => {
-  if (nextPreviousContainer) {
+  if (nextPreviousContainer && category) {
     const categoryIndex = page.categories.map(cat => urlify(cat.toLowerCase())).indexOf(category.toLowerCase())
     if (categoryIndex !== -1) {
       return pages.find(
@@ -59,6 +59,7 @@ export const getAdjacentCategoryPage = (page, category, pages, nextPreviousConta
       console.log('-1 next', page.categories, category)
     }
   }
+  return null
 }
 
 export const getPreviousPageData = (page, category, pages) => {
@@ -67,11 +68,12 @@ export const getPreviousPageData = (page, category, pages) => {
   let url
   let text
   if (!previousPage) {
-    url = '/'
-    text = 'Homepage'
-  } else {
-    text = previousPage.title
+    return {
+      url: '/',
+      text: 'Homepage',
+    }
   }
+  text = previousPage.title
 
   const sameCategory =
     previousPage &&


### PR DESCRIPTION
Category sidebar for pages.

![2019-04-18 11 27 46 localhost de327be88e5c](https://user-images.githubusercontent.com/1894894/56355169-8b9ca680-61cd-11e9-8973-c468f5471512.png)

This provides an easier navigation.

What is working:
+ Generated automatically on pages
+ Add this menu on the side of Overview page (may be removed later, for now its for consistency)
+ Theme is done
+ Links on the menu
+ Previous and next link. To do this, `PageContent.js` has been refactored to provide easy access to next and previous page.

Issue: #39